### PR TITLE
fix ".env: not found" error

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -22,7 +22,7 @@ SSLCERTIFICATEFOLDER="$CONFIGFOLDER/nginx/ssl"
 # ENVIRONMENTVARIABLESFILE contains the path
 # to the file that holds the required environment
 # variables for this script.
-ENVIRONMENTVARIABLESFILE=".env"
+ENVIRONMENTVARIABLESFILE="$PROJECTPATH/.env"
 if [ ! -f $ENVIRONMENTVARIABLESFILE ]; then
   echo >&2 "The file that holds the environment variables was not found at $ENVIRONMENTVARIABLESFILE"
   exit 1


### PR DESCRIPTION
dockerize-magento2$ bin/console install localhost
bin/console: 40: .: .env: not found