### PR TITLE
Add MailHog container and install mhsendmail in PHP container

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -267,6 +267,7 @@ installMagento() {
   printf "%-15s%-30s\n" "Backend" $backendURL
   printf "%-15s%s: %s\n" "" "Username" ${ADMIN_USERNAME}
   printf "%-15s%s: %s\n" "" "Password" ${ADMIN_PASSWORD}
+  printf "%-15s%-30s\n" "Mails" "http://${hostname}:8025/"
 
 }
 

--- a/config/php/image/Dockerfile
+++ b/config/php/image/Dockerfile
@@ -95,3 +95,8 @@ RUN cd /tmp/ && git clone https://github.com/xdebug/xdebug.git \
     && touch /usr/local/etc/php/ext-xdebug.ini \
     && rm -r /tmp/xdebug \
     && apt-get purge -y --auto-remove
+
+# Install Mailhog
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install golang-go
+RUN mkdir /opt/go && export GOPATH=/opt/go && go get github.com/mailhog/mhsendmail
+RUN touch /usr/local/etc/php/mailhog.ini

--- a/config/php/mailhog.ini
+++ b/config/php/mailhog.ini
@@ -1,0 +1,3 @@
+[mail function]
+sendmail_path = "/opt/go/bin/mhsendmail --smtp-addr=mailhog:1025"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ./config/php/php.ini:/usr/local/etc/php/php.ini
       - ./config/php/php-fpm.conf:/usr/local/etc/php-fpm.conf
       - ./config/php/ext-xdebug.ini:/usr/local/etc/php/conf.d/ext-xdebug.ini
+      - ./config/php/mailhog.ini:/usr/local/etc/php/conf.d/mailhog.ini
     volumes_from:
       - appdata
     env_file: .env
@@ -71,6 +72,14 @@ services:
     environment:
       PMA_HOST: "mysql"
       PMA_PORT: 3306
+    networks:
+      - front
+      - back
+
+    mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "8025:8025"
     networks:
       - front
       - back


### PR DESCRIPTION
MailHog shows all outgoing emails in a web interface instead of actually sending them. I assume that this repository is meant to be used for development, otherwise we'll have to make it optional (via environment variable?)